### PR TITLE
new ops: DepthToSpace, Expand, Resample2D

### DIFF
--- a/Barracuda/Editor/ONNXModelImporter.cs
+++ b/Barracuda/Editor/ONNXModelImporter.cs
@@ -110,6 +110,16 @@ namespace Unity.Barracuda
                     Output(node, rank:symbolicShape.Length);
                 }
             });
+            Add("Expand", (net, node) => {
+                var onnxShape = node.Input1Constant(onnxLayout: "C", name: "shape").AsLongs();
+                var symbolicShape = ONNXLayout.ConvertSymbolicShapeToBarracuda(onnxShape, "NCHW");
+                bool containsNoVariableDimensions = Array.IndexOf(symbolicShape, -1) == -1;
+                if (containsNoVariableDimensions && forceArbitraryBatchSize)
+                    symbolicShape[0] = -1; // force arbitrary batch size
+
+                net.Expand(node.Name, node.Input0, symbolicShape);
+                Output(node, rank:symbolicShape.Length);
+            });
             Add("Shape", (net, node)    => {
                 float[] shapeValuesAsFloats;
                 if (node.IsInput0Const)
@@ -522,7 +532,17 @@ namespace Unity.Barracuda
                     // TODO: support sizes
                 }
 
-                Resize2D(net, node, node.Scales, node.ModeOptional("nearest"));
+                var sizes = node.Sizes;
+                if (sizes != null)
+                {
+                    var mode = node.ModeOptional("nearest");
+                    var bilinear = IsModeBilinear(net, node, mode);
+                    net.Resample2D(node.Name, node.Input0, node.Sizes, bilinear);
+                }
+                else
+                { 
+                    Resize2D(net, node, node.Scales, node.ModeOptional("nearest"));
+                }
             });
             Add("Transpose", (net, node) =>
             {
@@ -579,6 +599,9 @@ namespace Unity.Barracuda
                         throw new OnnxLayerImportException(
                             $"Currently only constant inputs for node of type {node.OperatorType} are supported. Instead input of {node.Name} is pointing to non-constant node {node.Input0}.");
                 }
+            });
+            Add("DepthToSpace", (net, node) => {
+                net.DepthToSpace(node.Name, node.Input0, node.BlockSize, node.ModeOptional("DCR"));
             });
 
             // Tensor ops

--- a/Barracuda/Editor/ONNXNodeWrapper.cs
+++ b/Barracuda/Editor/ONNXNodeWrapper.cs
@@ -96,6 +96,7 @@ namespace Unity.Barracuda
         public float Seed { get { return GetOptionalFloat("seed", 1337f); } } // seed is always optional and defaults to 'auto generated'
         public ONNXTensor ValueAsTensor { get { return GetRequiredTensor("value"); } }
         public int Axis { get { return GetRequiredInt("axis"); } }
+        public int BlockSize { get { return GetRequiredInt("blocksize"); } }
         public int Group { get { return GetRequiredInt("group"); } }
         public long[] Shape { get { return GetRequiredLongArray("shape"); } }
         public int[] Starts { get { return GetRequiredIntArray("starts"); } }
@@ -109,6 +110,7 @@ namespace Unity.Barracuda
         internal bool SupportsSpatialOnlyPads { get { return OperatorType != "Pad"; } }
         public int[] Pads { get { return ConvertPadsToBarracuda(); } }
         public float[] Scales { get { return ConvertScalesToBarracuda(); } }
+        public int[] Sizes { get { return ConvertSizesToBarracuda(); } }
         public float AlphaOptional(float defaultValue) { return GetOptionalFloat("alpha", defaultValue); }
         public float BetaOptional(float defaultValue) { return GetOptionalFloat("beta", defaultValue); }
         public float GammaOptional(float defaultValue) { return GetOptionalFloat("gamma", defaultValue); }
@@ -424,6 +426,29 @@ namespace Unity.Barracuda
                     throw new OnnxLayerImportException(
                         $"Attribute pads of unsupported length {scales.Length} in {Name} ot fype {OperatorType}.");
             }
+        }
+
+        private int[] ConvertSizesToBarracuda()
+        {
+            int[] sizes = null;
+            Debug.Assert(OperatorType == "Resize");
+            Debug.Assert(InputCount == 4);
+
+            if (IsInput3Const)
+            {
+                sizes = Input3Constant(onnxLayout: "C", name: "sizes").AsInts();
+                Debug.Assert(sizes != null);
+                Debug.Assert(sizes.Length == 4);
+
+                if ((sizes[0] != 1) || (sizes[1] != 1))
+                    Warn("Only spatial (H and W) resizing is currently supported." +
+                        " Non spatial sizes (N and C) will be ignored and default to 1.");
+
+                // Skip non-spatial dimensions N, C, return WH (NCHW layout)
+                sizes = sizes.Skip(2).Reverse().ToArray();
+            }
+
+            return sizes;
         }
 
         public Tensor DefaultTensor(TensorShape tensorShape, float defaultValue)

--- a/Barracuda/Runtime/Core/Backends/BarracudaBackends.cs
+++ b/Barracuda/Runtime/Core/Backends/BarracudaBackends.cs
@@ -18,6 +18,8 @@ public interface IOps
     Tensor DepthwiseConv2D(Tensor x, Tensor k, Tensor b, int[] stride, int[] pad);
     Tensor Conv2DTrans(Tensor x, Tensor k, Tensor b, int[] stride, int[] pad, int[] outputAdjustment);
     Tensor Upsample2D(Tensor x, int[] scale, bool bilinear);
+    Tensor Resample2D(Tensor x, int[] size, bool bilinear);
+    Tensor DepthToSpace(Tensor x, int[] scale, Layer.DepthToSpaceMode mode);
     Tensor MaxPool2D(Tensor x, int[] pool, int[] stride, int[] pad);
     Tensor AvgPool2D(Tensor x, int[] pool, int[] stride, int[] pad);
     Tensor GlobalMaxPool2D(Tensor x); // @TODO: consider, if it should be just a special case of MaxPool2D with {pool=X.width/height, stride=1}
@@ -87,6 +89,7 @@ public interface IOps
 
     Tensor Flatten(Tensor x);
     Tensor Reshape(Tensor x, TensorShape shape);
+    Tensor Expand(Tensor x, TensorShape shape);
     Tensor Transpose(Tensor x);
 
     Tensor Concat(Tensor[] tensors, int axis);

--- a/Barracuda/Runtime/Core/Backends/BarracudaReferenceCPU.cs
+++ b/Barracuda/Runtime/Core/Backends/BarracudaReferenceCPU.cs
@@ -474,6 +474,83 @@ public class ReferenceCPUOps : IOps
         return O;
     }
 
+    public virtual Tensor Resample2D(Tensor X, int[] size, bool bilinear)
+    {
+        Assert.AreEqual(size.Length, 2);
+        var O = NewTensor(X.batch, size[1], size[0], X.channels);
+
+        float scaleX = O.width / (float) X.width;
+        float scaleY = O.height / (float) X.height;
+
+        for (int b = 0; b < O.batch; ++b)
+            for (int y = 0; y < O.height; ++y)
+                for (int x = 0; x < O.width; ++x)
+                    for (int c = 0; c < O.channels; ++c)
+                    {
+                        if (bilinear)
+                        {
+                            float srcPosX = (x + 0.5f) / scaleX - 0.5f;
+                            float srcPosY = (y + 0.5f) / scaleY - 0.5f;
+                            float floorSrcPosX = Mathf.Floor(srcPosX);
+                            float floorSrcPosY = Mathf.Floor(srcPosY);
+                            float fracSrcPosX = srcPosX - floorSrcPosX;
+                            float fracSrcPosY = srcPosY - floorSrcPosY;
+
+                            float p00 = X[X.IndexWithClamp(b, (int)floorSrcPosY + 0, (int)floorSrcPosX + 0, c)];
+                            float p01 = X[X.IndexWithClamp(b, (int)floorSrcPosY + 1, (int)floorSrcPosX + 0, c)];
+                            float p10 = X[X.IndexWithClamp(b, (int)floorSrcPosY + 0, (int)floorSrcPosX + 1, c)];
+                            float p11 = X[X.IndexWithClamp(b, (int)floorSrcPosY + 1, (int)floorSrcPosX + 1, c)];
+                            float v =
+                                p00 * (1 - fracSrcPosX) * (1 - fracSrcPosY) +
+                                p01 * (1 - fracSrcPosX) * fracSrcPosY +
+                                p10 * fracSrcPosX * (1 - fracSrcPosY) +
+                                p11 * fracSrcPosX * fracSrcPosY;
+                            O[b, y, x, c] = v;
+                        }
+                        else
+                        {
+                            var srcY = Mathf.FloorToInt(y / scaleY);
+                            var srcX = Mathf.FloorToInt(x / scaleX);
+                            O[b, y, x, c] = X[X.IndexWithClamp(b, srcY, srcX, c)];
+                        }
+                    }
+        return O;
+    }
+
+
+    public virtual Tensor DepthToSpace(Tensor X, int[] blocksize, Layer.DepthToSpaceMode mode)
+    {
+        Assert.AreEqual(blocksize.Length, 2);
+        int bsX = blocksize[0];
+        int bsY = blocksize[1];
+
+        Assert.AreEqual(X.channels % (bsX * bsY), 0);
+
+        var O = NewTensor(X.batch, X.height * bsY, X.width * bsX, X.channels / (bsX * bsY));
+
+        for (int b = 0; b < O.batch; ++b)
+            for (int y = 0; y < O.height; ++y)
+                for (int x = 0; x < O.width; ++x)
+                    for (int c = 0; c < O.channels; ++c)
+                    {
+                        int iy = y / bsY;
+                        int by = y % bsY;
+                        int ix = x / bsX;
+                        int bx = x % bsX;
+                        switch (mode)
+                        {
+                            case Layer.DepthToSpaceMode.CRD:
+                                O[b, y, x, c] = X[b, iy, ix, (c * bsX * bsY) + (by * bsX) + bx];
+                                break;
+                            case Layer.DepthToSpaceMode.DCR:
+                                O[b, y, x, c] = X[b, iy, ix, (by * bsX * O.channels) + (bx * O.channels) + c];
+                                break;
+                        }
+                    }
+
+        return O;
+    }
+
     public virtual Tensor MaxPool2D(Tensor X, int[] pool, int[] stride, int[] pad)
     {
         Assert.AreEqual(pool.Length, 2);
@@ -1852,6 +1929,31 @@ public class ReferenceCPUOps : IOps
 
         // otherwise deep copy
         return CopyAndReshape(X, newShape);
+    }
+
+    public virtual Tensor Expand(Tensor X, TensorShape newShape)
+    {
+        Assert.IsTrue(newShape.batch == X.batch || X.batch == 1);
+        Assert.IsTrue(newShape.height == X.height || X.height == 1);
+        Assert.IsTrue(newShape.width == X.width || X.width == 1);
+        Assert.IsTrue(newShape.channels == X.channels || X.channels == 1);
+
+        // scale is either 1 or 0 in case of expansion
+        int bS = X.batch / newShape.batch;
+        int hS = X.height / newShape.height;
+        int wS = X.width / newShape.width;
+        int cS = X.channels / newShape.channels;
+
+        var O = NewTensor(newShape);
+        for (int b = 0; b < newShape.batch; ++b)
+            for (int y = 0; y < newShape.height; ++y)
+                for (int x = 0; x < newShape.width; ++x)
+                    for (int c = 0; c < newShape.channels; ++c)
+                    {    
+                        // sample either from dim or index 0 in case of expansion
+                        O[b, y, x, c] = X[b * bS, y * hS, x * wS, c * cS];
+                    }
+        return O;
     }
 
     public virtual Tensor Gather(Tensor[] tensors, int axis)

--- a/Barracuda/Runtime/Core/Backends/CompareOps.cs
+++ b/Barracuda/Runtime/Core/Backends/CompareOps.cs
@@ -85,6 +85,20 @@ public class CompareOps : IOps, IModelCompiler
         CheckSame(Y, Z, Layer.Type.Upsample2D);
         return Y;
     }
+    Tensor IOps.Resample2D(Tensor X, int[] size, bool bilinear)
+    {
+        var Y = m_Ops1.Resample2D(X, size, bilinear);
+        var Z = m_Ops2.Resample2D(X, size, bilinear);
+        CheckSame(Y, Z, Layer.Type.Resample2D);
+        return Y;
+    }
+    Tensor IOps.DepthToSpace(Tensor X, int[] scale, Layer.DepthToSpaceMode mode)
+    {
+        var Y = m_Ops1.DepthToSpace(X, scale, mode);
+        var Z = m_Ops2.DepthToSpace(X, scale, mode);
+        CheckSame(Y, Z, Layer.Type.DepthToSpace);
+        return Y;
+    }
     Tensor IOps.MaxPool2D(Tensor X, int[] pool, int[] stride, int[] pad)
     {
         var Y = m_Ops1.MaxPool2D(X, pool, stride, pad);
@@ -527,6 +541,13 @@ public class CompareOps : IOps, IModelCompiler
         var Y = m_Ops1.Reshape(X, shape);
         var Z = m_Ops2.Reshape(X, shape);
         CheckSame(Y, Z, Layer.Type.Reshape);
+        return Y;
+    }
+    Tensor IOps.Expand(Tensor X, TensorShape shape)
+    {
+        var Y = m_Ops1.Expand(X, shape);
+        var Z = m_Ops2.Expand(X, shape);
+        CheckSame(Y, Z, Layer.Type.Expand);
         return Y;
     }
     Tensor IOps.Transpose(Tensor X)

--- a/Barracuda/Runtime/Core/Backends/ModelAnalyzer.cs
+++ b/Barracuda/Runtime/Core/Backends/ModelAnalyzer.cs
@@ -140,6 +140,31 @@ public class ModelAnalyzer
                 }
             }
             else if (
+                l.type == Layer.Type.Resample2D)
+            {
+                if(inputShapes.Count > 1)
+                {
+                    O = null;
+                }
+                else
+                {
+                    // pool is treated as resample size here
+                    var size = l.pool;
+                    Assert.IsNotNull(size);
+                    Assert.AreEqual(size.Length, 2);
+                    O = new TensorShape(X.batch, size[1], size[0], X.channels);
+                }
+            }
+            else if (
+                l.type == Layer.Type.DepthToSpace)
+            {
+                    // pool size is treated as blocksize here
+                    Assert.IsNotNull(l.pool);
+                    Assert.AreEqual(l.pool.Length, 2);
+                    Assert.AreEqual(X.channels % (l.pool[0] * l.pool[1]), 0);
+                    O = new TensorShape(X.batch, X.height * l.pool[1], X.width * l.pool[0], X.channels / (l.pool[0] * l.pool[1]));
+            }
+            else if (
                 l.type == Layer.Type.MaxPool2D ||
                 l.type == Layer.Type.AvgPool2D)
             {
@@ -283,6 +308,17 @@ public class ModelAnalyzer
 
                 Assert.AreEqual(size.Length, 4);
                 O = X.Reshape(size);
+            }
+            else if (
+                l.type == Layer.Type.Expand)
+            {
+                // pool size is treated as new shape
+                var newShape = l.pool;
+
+                Assert.IsNotNull(newShape);
+                Assert.AreEqual(newShape.Length, 4);
+
+                O = new TensorShape(newShape);
             }
             else if (
                 l.type == Layer.Type.Transpose)

--- a/Barracuda/Runtime/Core/Backends/StatsOps.cs
+++ b/Barracuda/Runtime/Core/Backends/StatsOps.cs
@@ -98,12 +98,25 @@ public class StatsOps : IOps, IModelCompiler
         m_Alu += m * n * k * 2L;
         m_Mem += (long)X.length + (long)K.length + (long)B.length + (long)O.length;
         return O;
-    }
+        }
     Tensor IOps.Upsample2D(Tensor X, int[] scale, bool bilinear)
     {
         var O = m_Ops.Upsample2D(X, scale, bilinear);
         m_Alu += (long)O.length * (bilinear ? 8 : 1);
         m_Mem += (long)X.length * (bilinear ? 4 : 1) + (long)O.length;
+        return O;
+    }
+    Tensor IOps.Resample2D(Tensor X, int[] size, bool bilinear)
+    {
+        var O = m_Ops.Resample2D(X, size, bilinear);
+        m_Alu += (long)O.length * (bilinear ? 8 : 1);
+        m_Mem += (long)X.length * (bilinear ? 4 : 1) + (long)O.length;
+        return O;
+    }
+    Tensor IOps.DepthToSpace(Tensor X, int[] scale, Layer.DepthToSpaceMode mode)
+    {
+        var O = m_Ops.DepthToSpace(X, scale, mode);
+        m_Mem += (long)X.length + (long)O.length;
         return O;
     }
     Tensor IOps.MaxPool2D(Tensor X, int[] pool, int[] stride, int[] pad)
@@ -460,6 +473,12 @@ public class StatsOps : IOps, IModelCompiler
     Tensor IOps.Reshape(Tensor X, TensorShape shape)
     {
         return m_Ops.Reshape(X, shape);
+    }
+    Tensor IOps.Expand(Tensor X, TensorShape shape)
+    {
+        var O = m_Ops.Expand(X, shape);
+        m_Mem += (long)X.length + (long)O.length;
+        return O;
     }
     Tensor IOps.Transpose(Tensor X)
     {

--- a/Barracuda/Runtime/Core/Backends/VerboseOps.cs
+++ b/Barracuda/Runtime/Core/Backends/VerboseOps.cs
@@ -75,6 +75,20 @@ public class VerboseOps : IOps, IModelCompiler
         O.PrintDataPart(32, Prefix + "Upsample2D");
         return O;
     }
+    Tensor IOps.Resample2D(Tensor X, int[] size, bool bilinear)
+    {
+        var O = m_Ops.Resample2D(X, size, bilinear);
+        D.Log(X.shape + " ^ " + (bilinear ? "bilinear" : "") + O.shape);
+        O.PrintDataPart(32, Prefix + "Resample2D");
+        return O;
+    }
+    Tensor IOps.DepthToSpace(Tensor X, int[] scale, Layer.DepthToSpaceMode mode)
+    {
+        var O = m_Ops.DepthToSpace(X, scale, mode);
+        D.Log(X.shape + " ^ " + mode + O.shape);
+        O.PrintDataPart(32, Prefix + "DepthToSpace");
+        return O;
+    }
     Tensor IOps.MaxPool2D(Tensor X, int[] pool, int[] stride, int[] pad)
     {
         var O = m_Ops.MaxPool2D(X, pool, stride, pad);
@@ -510,6 +524,12 @@ public class VerboseOps : IOps, IModelCompiler
     Tensor IOps.Reshape(Tensor X, TensorShape shape)
     {
         var O = m_Ops.Reshape(X, shape);
+        D.Log(X.shape + " $ " + O.shape);
+        return O;
+    }
+    Tensor IOps.Expand(Tensor X, TensorShape shape)
+    {
+        var O = m_Ops.Expand(X, shape);
         D.Log(X.shape + " $ " + O.shape);
         return O;
     }

--- a/Barracuda/Runtime/Core/Model.cs
+++ b/Barracuda/Runtime/Core/Model.cs
@@ -82,6 +82,10 @@ public class Layer
         Squeeze = 203,              // TODO: NOT IMPLEMENTED
         Unsqueeze = 204,            // TODO: NOT IMPLEMENTED
         Gather = 205,
+        DepthToSpace = 206,
+        SpaceToDepth = 207,         // TODO: NOT IMPLEMENTED
+        Expand = 208,
+        Resample2D = 209,
 
         Concat = 210,
         StridedSlice = 211,
@@ -158,6 +162,12 @@ public class Layer
         Valid = 0,
         SameUpper = -1,
         SameLower = -2,
+    }
+
+    public enum DepthToSpaceMode
+    {
+        DCR,
+        CRD
     }
 
     public struct DataSet

--- a/Barracuda/Runtime/Core/ModelBuilder.cs
+++ b/Barracuda/Runtime/Core/ModelBuilder.cs
@@ -382,6 +382,47 @@ namespace Unity.Barracuda
         }
 
         /// <summary>
+        /// Resample2D scales the input tensor to the given resolution.
+        /// `bilinear` allows to choose between nearest neighbour or bilinear sampling.
+        /// </summary>
+        public Layer Resample2D(string name, object input, Int32[] size, bool bilinear)
+        {
+            Layer layer = new Layer(name, Layer.Type.Resample2D);
+            layer.pool = size;
+            layer.axis = bilinear ? 1 : -1;
+            layer.inputs = new[] { ResolveInput(input) };
+
+            m_Model.layers.Add(layer);
+
+            return layer;
+        }
+
+        /// <summary>
+        /// DepthToSpace rearranges (permutes) data from depth into blocks of
+        /// spatial data. This is the reverse transformation of SpaceToDepth.
+        /// More specifically, this op outputs a copy of the input tensor where
+        /// values from the depth dimension are moved in spatial blocks to the
+        /// height and width dimensions. By default, mode = DCR. In the DCR mode,
+        /// elements along the depth dimension from the input tensor are rearranged
+        /// in the following order: depth, column, and then row.
+        /// In the CRD mode, elements along the depth dimension from the input
+        /// tensor are rearranged in the following order: column, row, and depth.
+        /// </summary>
+        public Layer DepthToSpace(string name, object source, int blocksize, string mode)
+        {
+            Layer layer = new Layer(name, Layer.Type.DepthToSpace);
+
+            layer.pool = new int[] { blocksize, blocksize };
+            layer.axis = (int)(Layer.DepthToSpaceMode)Enum.Parse(typeof(Layer.DepthToSpaceMode), mode);
+            layer.inputs = new[] { ResolveInput(source) };
+
+            m_Model.layers.Add(layer);
+
+            return layer;
+        }
+
+
+        /// <summary>
         /// Apply symbolic shape to input tensor. Symbolic shape can have up to one dimension specified as unknown (value -1).
         /// </summary>
         public Layer Reshape(string name, object input, int[] shape)
@@ -412,6 +453,22 @@ namespace Unity.Barracuda
 
             Layer layer = new Layer(name, Layer.Type.Reshape);
             layer.inputs = new [] {ResolveInput(input), ResolveInput(shapeLike)};
+
+            m_Model.layers.Add(layer);
+
+            return layer;
+        }
+
+        /// <summary>
+        /// Broadcast the input tensor following the given shape and similar to
+        /// numpy.array(input) * numpy.ones(shape). Two corresponding dimension
+        /// must have the same value, or the input dimension is 1.
+        /// </summary>
+        public Layer Expand(string name, object input, int[] shape)
+        {
+            Layer layer = new Layer(name, Layer.Type.Expand);
+            layer.inputs = new[] { ResolveInput(input) };
+            layer.pool = shape;
 
             m_Model.layers.Add(layer);
 

--- a/Barracuda/Runtime/Core/Resources/BarracudaReferenceImpl.compute
+++ b/Barracuda/Runtime/Core/Resources/BarracudaReferenceImpl.compute
@@ -12,6 +12,14 @@
 #pragma kernel Upsample2D_NCHW CHANNELS_FIRST=1
 #pragma kernel UpsampleBilinear2D_NHWC CHANNELS_FIRST=0
 #pragma kernel UpsampleBilinear2D_NCHW CHANNELS_FIRST=1
+#pragma kernel Resample2D_NHWC CHANNELS_FIRST=0
+#pragma kernel Resample2D_NCHW CHANNELS_FIRST=1
+#pragma kernel ResampleBilinear2D_NHWC CHANNELS_FIRST=0
+#pragma kernel ResampleBilinear2D_NCHW CHANNELS_FIRST=1
+#pragma kernel DepthToSpace_CRD_NHWC CHANNELS_FIRST=0
+#pragma kernel DepthToSpace_CRD_NCHW CHANNELS_FIRST=1
+#pragma kernel DepthToSpace_DCR_NHWC CHANNELS_FIRST=0
+#pragma kernel DepthToSpace_DCR_NCHW CHANNELS_FIRST=1
 #pragma kernel Unstride2D_NHWC CHANNELS_FIRST=0
 #pragma kernel Unstride2D_NCHW CHANNELS_FIRST=1
 #pragma kernel MaxPool2D_NHWC CHANNELS_FIRST=0
@@ -131,6 +139,8 @@
 #pragma kernel StridedSlice_NCHW CHANNELS_FIRST=1
 #pragma kernel Gather_NHWC CHANNELS_FIRST=0
 #pragma kernel Gather_NCHW CHANNELS_FIRST=1
+#pragma kernel Expand_NHWC CHANNELS_FIRST=0
+#pragma kernel Expand_NCHW CHANNELS_FIRST=1
 
 #include "Tensor.cginc"
 #include "Random.cginc"
@@ -1179,6 +1189,126 @@ void KERNEL_FUNC(UpsampleBilinear2D)(uint3 dispatchThreadID : SV_DispatchThreadI
 }
 
 [numthreads(4,4,4)]
+void KERNEL_FUNC(Resample2D)(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DISPATCH_ARGS(O.channels, O.width, O.height);
+    TENSOR_ARGS2(X, O);
+
+    uint c = dispatchThreadID.x;
+    uint x = dispatchThreadID.y;
+    uint y = dispatchThreadID.z;
+
+    if (c >= O.channels) return;
+    if (x >= O.width) return;
+    if (y >= O.height) return;
+    
+    float2 dstSize = float2(O.width, O.height);
+    float2 srcSize = float2(X.width, X.height);
+    float2 dstPos = float2(x, y);
+    float2 srcPos = floor(dstPos * (srcSize / dstSize));
+
+    for (uint n = 0; n < O.batch; ++n)
+    {
+        float v = X.ClampGet(n, srcPos, c);
+        O.Set(n, y, x, c, v);
+    }
+}
+
+[numthreads(4,4,4)]
+void KERNEL_FUNC(ResampleBilinear2D)(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DISPATCH_ARGS(O.channels, O.width, O.height);
+    TENSOR_ARGS2(X, O);
+
+    uint c = dispatchThreadID.x;
+    uint x = dispatchThreadID.y;
+    uint y = dispatchThreadID.z;
+
+    if (c >= O.channels) return;
+    if (x >= O.width) return;
+    if (y >= O.height) return;
+    
+    float2 dstSize = float2(O.width, O.height);
+    float2 srcSize = float2(X.width, X.height);
+    float2 dstPos = float2(x, y);
+    float2 srcPos = (dstPos + 0.5) * (srcSize / dstSize) - 0.5;
+
+    for (uint n = 0; n < O.batch; ++n)
+    {
+        float p00 = X.ClampGet(n, floor(srcPos) + float2(0, 0), c);
+        float p01 = X.ClampGet(n, floor(srcPos) + float2(0, 1), c);
+        float p10 = X.ClampGet(n, floor(srcPos) + float2(1, 0), c);
+        float p11 = X.ClampGet(n, floor(srcPos) + float2(1, 1), c);
+
+        float v =
+            p00 * (1-frac(srcPos.x)) * (1-frac(srcPos.y)) +
+            p01 * (1-frac(srcPos.x)) *    frac(srcPos.y)  +
+            p10 *    frac(srcPos.x)  * (1-frac(srcPos.y)) +
+            p11 *    frac(srcPos.x)  *    frac(srcPos.y);
+
+        O.Set(n, y, x, c, v);
+    }
+}
+
+[numthreads(4,4,4)]
+void KERNEL_FUNC(DepthToSpace_CRD)(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DISPATCH_ARGS(O.width, O.height, O.channels);
+    TENSOR_ARGS2(X, O)
+
+    uint c = dispatchThreadID.x;
+    uint x = dispatchThreadID.y;
+    uint y = dispatchThreadID.z;
+
+    if (c >= O.channels) return;
+    if (x >= O.width) return;
+    if (y >= O.height) return;
+    
+    uint bsX = _Pool.x;
+    uint bsY = _Pool.y;
+
+    for (uint b = 0; b < O.batch; ++b)
+    {
+        uint iy = y / bsY;
+        uint by = y % bsY;
+        uint ix = x / bsX;
+        uint bx = x % bsX;
+        
+        float v =  X.Get(b, iy, ix, (c * bsX * bsY) + (by * bsX) + bx);
+        O.Set(b, y, x, c, v);
+    }
+}
+
+[numthreads(4,4,4)]
+void KERNEL_FUNC(DepthToSpace_DCR)(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DISPATCH_ARGS(O.width, O.height, O.channels);
+    TENSOR_ARGS2(X, O)
+
+    uint c = dispatchThreadID.x;
+    uint x = dispatchThreadID.y;
+    uint y = dispatchThreadID.z;
+
+    if (c >= O.channels) return;
+    if (x >= O.width) return;
+    if (y >= O.height) return;
+    
+    uint bsX = _Pool.x;
+    uint bsY = _Pool.y;
+
+    for (uint b = 0; b < O.batch; ++b)
+    {
+        uint iy = y / bsY;
+        uint by = y % bsY;
+        uint ix = x / bsX;
+        uint bx = x % bsX;
+        
+        float v =  X.Get(b, iy, ix, (by * bsX * O.channels) + (bx * O.channels) + c);
+        O.Set(b, y, x, c, v);
+    }
+}
+
+[numthreads(4,4,4)]
 void KERNEL_FUNC(MaxPool2D)(uint3 dispatchThreadID : SV_DispatchThreadID)
 {
     DISPATCH_ARGS(O.channels, O.width, O.height);
@@ -1944,5 +2074,33 @@ void KERNEL_FUNC(Gather)(uint3 dispatchThreadID : SV_DispatchThreadID)
             v = X.Get(n, y, x, (uint)K.FastGet(c));
 
         O.Set(n, y, x, c, v);
+    }
+}
+
+[numthreads(4, 4, 4)]
+void KERNEL_FUNC(Expand)(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    DISPATCH_ARGS(O.channels, O.width, O.height);
+    TENSOR_ARGS2(X, O);
+
+    uint c = dispatchThreadID.x;
+    uint x = dispatchThreadID.y;
+    uint y = dispatchThreadID.z;
+
+    if (c >= O.channels) return;
+    if (x >= O.width) return;
+    if (y >= O.height) return;
+    
+    // scale is either 1 or 0 in case of expansion
+    uint bS = X.batch / O.batch;
+    uint hS = X.height / O.height;
+    uint wS = X.width / O.width;
+    uint cS = X.channels / O.channels;
+
+    for (uint b = 0; b < O.batch; ++b)
+    {
+        // sample either from dim or index 0 in case of expansion
+        float v =  X.Get(b * bS, y * hS, x * wS, c * cS);
+        O.Set(b, y, x, c, v);
     }
 }


### PR DESCRIPTION
Resample2D to implements Resize with given size
this op is exported by pytorch 1.3.1 at onnx opset 11 for F.interpolate
also included: naive CPU & GPU implementation for Expand & DepthToSpace