### PR TITLE
Update documentation: fix images, clarify package manager

### DIFF
--- a/Documentation~/GettingStarted.md
+++ b/Documentation~/GettingStarted.md
@@ -19,9 +19,9 @@ Loading a trained model is divided into two steps:
 
 To load an ONNX model, add its .onnx file to your project's `Asset` folder. The model is imported and shows up as an asset of type `NNModel`.
 
-![Assets](images/Assets.png) 
+![Assets](images/assets.png) 
 
-![Inspector](images/Inspector.png)
+![Inspector](images/inspector.png)
 
 
 You can then reference this asset directly in your script as follows:

--- a/Documentation~/Installing.md
+++ b/Documentation~/Installing.md
@@ -6,6 +6,8 @@ You can get Barracuda from:
 
 ## Unity Package Manager
 
+Installation via the package manager is only supported on Unity versions before 2020.3. For versions after 2020.3, use the GitHub method.
+
 In the Unity Editor, open the [Package Manager window](https://docs.unity3d.com/Manual/upm-ui.html), select Barracuda and install it:
 
 ![Install packages](images/InstallPackages.png)

--- a/Documentation~/Loading.md
+++ b/Documentation~/Loading.md
@@ -6,9 +6,9 @@ Before you import a trained model, you must have [exported your model to the ONN
 
 When you have a valid ONNX model, import it into your project; to do this, add the `.onnx` file to your project's `Assets` folder. Unity imports the model as an `NNModel` asset:
 
-![Assets](images/Assets.png) 
+![Assets](images/assets.png)
 
-![Assets](images/Inspector.png)
+![Assets](images/inspector.png)
 
 
 You can then reference this asset directly in your script as follows:


### PR DESCRIPTION
I don't believe you can install this via the package manager anymore - Unity has migrated to using the Unity Asset Store which does not have Barracuda in it.