### PR TITLE
Added deprecation banner to all documentation pages

### DIFF
--- a/Documentation~/AdvancedTopics.md
+++ b/Documentation~/AdvancedTopics.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Advanced topics

--- a/Documentation~/AdvancedTopics.md
+++ b/Documentation~/AdvancedTopics.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Advanced topics

--- a/Documentation~/AdvancedTopics.md
+++ b/Documentation~/AdvancedTopics.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Advanced topics
 
 This section provides more information on the following topics:

--- a/Documentation~/Exporting.md
+++ b/Documentation~/Exporting.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Exporting your model to ONNX format

--- a/Documentation~/Exporting.md
+++ b/Documentation~/Exporting.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Exporting your model to ONNX format
 
 To use your trained neural network in Unity, you need to export it to the [ONNX](https://onnx.ai/) format. 

--- a/Documentation~/Exporting.md
+++ b/Documentation~/Exporting.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Exporting your model to ONNX format

--- a/Documentation~/FAQ.md
+++ b/Documentation~/FAQ.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Frequently Asked Questions (FAQ)
 
 **Q.** Does Barracuda work on iPhone / Android / Magic Leap / Switch / PS4 / Xbox?

--- a/Documentation~/FAQ.md
+++ b/Documentation~/FAQ.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Frequently Asked Questions (FAQ)

--- a/Documentation~/FAQ.md
+++ b/Documentation~/FAQ.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Frequently Asked Questions (FAQ)

--- a/Documentation~/GettingStarted.md
+++ b/Documentation~/GettingStarted.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Getting started with Barracuda

--- a/Documentation~/GettingStarted.md
+++ b/Documentation~/GettingStarted.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Getting started with Barracuda
 
 This guide provides a brief overview on how to use Barracuda and run neural networks in Unity.

--- a/Documentation~/GettingStarted.md
+++ b/Documentation~/GettingStarted.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Getting started with Barracuda

--- a/Documentation~/Installing.md
+++ b/Documentation~/Installing.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Installing Barracuda

--- a/Documentation~/Installing.md
+++ b/Documentation~/Installing.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Installing Barracuda

--- a/Documentation~/Installing.md
+++ b/Documentation~/Installing.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Installing Barracuda
 
 You can get Barracuda from: 

--- a/Documentation~/Loading.md
+++ b/Documentation~/Loading.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Importing a trained model
 
 Before you import a trained model, you must have [exported your model to the ONNX format](Exporting.md).

--- a/Documentation~/Loading.md
+++ b/Documentation~/Loading.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Importing a trained model

--- a/Documentation~/Loading.md
+++ b/Documentation~/Loading.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Importing a trained model

--- a/Documentation~/MemoryManagement.md
+++ b/Documentation~/MemoryManagement.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Memory management

--- a/Documentation~/MemoryManagement.md
+++ b/Documentation~/MemoryManagement.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Memory management
 As a Barracuda user you are responsible for calling `Dispose()` on any worker, inputs and sometimes outputs. You must call `Dispose()` on outputs if you obtain them via `worker.CopyOutput()` or if you take ownership of them by calling `tensor.TakeOwnership()`.  
 

--- a/Documentation~/MemoryManagement.md
+++ b/Documentation~/MemoryManagement.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Memory management

--- a/Documentation~/ModelExecution.md
+++ b/Documentation~/ModelExecution.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Model execution
 
 In order to execute a model in Barracuda you must first [load the model](Loading.md) and [create a `Worker`](Worker.md).

--- a/Documentation~/ModelExecution.md
+++ b/Documentation~/ModelExecution.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Model execution

--- a/Documentation~/ModelExecution.md
+++ b/Documentation~/ModelExecution.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Model execution

--- a/Documentation~/ModelOutput.md
+++ b/Documentation~/ModelOutput.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Working with outputs

--- a/Documentation~/ModelOutput.md
+++ b/Documentation~/ModelOutput.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Working with outputs

--- a/Documentation~/ModelOutput.md
+++ b/Documentation~/ModelOutput.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Working with outputs
 
 After [executing a model](ModelExecution.md) you can then retrieve outputs or intermediate information.

--- a/Documentation~/SupportedArchitectures.md
+++ b/Documentation~/SupportedArchitectures.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Supported neural architectures and models

--- a/Documentation~/SupportedArchitectures.md
+++ b/Documentation~/SupportedArchitectures.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Supported neural architectures and models
 
 Barracuda currently supports the following neural architectures and models: 

--- a/Documentation~/SupportedArchitectures.md
+++ b/Documentation~/SupportedArchitectures.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Supported neural architectures and models

--- a/Documentation~/SupportedOperators.md
+++ b/Documentation~/SupportedOperators.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Supported ONNX operators
 
 Barracuda currently supports the following [ONNX operators](https://github.com/onnx/onnx/blob/master/docs/Operators.md) and parameters. If an operator is not  on the list and you need it, please create a ticket on the [Unity Barracuda GitHub](https://github.com/Unity-Technologies/barracuda-release/issues).

--- a/Documentation~/SupportedOperators.md
+++ b/Documentation~/SupportedOperators.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Supported ONNX operators

--- a/Documentation~/SupportedOperators.md
+++ b/Documentation~/SupportedOperators.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Supported ONNX operators

--- a/Documentation~/SupportedPlatforms.md
+++ b/Documentation~/SupportedPlatforms.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Supported platforms

--- a/Documentation~/SupportedPlatforms.md
+++ b/Documentation~/SupportedPlatforms.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Supported platforms
 
 Barracuda supports the following platforms: 

--- a/Documentation~/SupportedPlatforms.md
+++ b/Documentation~/SupportedPlatforms.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Supported platforms

--- a/Documentation~/TensorHandling.md
+++ b/Documentation~/TensorHandling.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Working with data
 
 ## Tensor

--- a/Documentation~/TensorHandling.md
+++ b/Documentation~/TensorHandling.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Working with data

--- a/Documentation~/TensorHandling.md
+++ b/Documentation~/TensorHandling.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Working with data

--- a/Documentation~/VisualizingModel.md
+++ b/Documentation~/VisualizingModel.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # Visualizing Model
 
 It can be useful to visualize a model both before and after it is imported into Barracuda.

--- a/Documentation~/VisualizingModel.md
+++ b/Documentation~/VisualizingModel.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # Visualizing Model

--- a/Documentation~/VisualizingModel.md
+++ b/Documentation~/VisualizingModel.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # Visualizing Model

--- a/Documentation~/Worker.md
+++ b/Documentation~/Worker.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 # IWorker interface: core of the engine

--- a/Documentation~/Worker.md
+++ b/Documentation~/Worker.md
@@ -1,3 +1,7 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 # IWorker interface: core of the engine
 
 The core engine interface in Barracuda is called `IWorker`. `IWorker` breaks down the model into executable tasks and schedules them on GPU or CPU.

--- a/Documentation~/Worker.md
+++ b/Documentation~/Worker.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 # IWorker interface: core of the engine

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -6,7 +6,7 @@
 
 # Introduction to Barracuda
 
-**Note:** The Barracuda package has been replaced by the `Sentis` package, which is in a closed beta phase. Refer to the [Sentis documentation](https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html) for more information.
+**Note:** The Barracuda package has been replaced by the `Sentis` package, which is in a closed beta phase. Refer to the [Sentis documentation](https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html) for more information.
 You can [sign up for the closed beta](https://create.unity.com/ai-beta).
 
 The Barracuda package is a lightweight cross-platform [neural network](https://en.wikipedia.org/wiki/Neural_network) inference library for Unity.  

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
 </div>
 
 ![Barracuda landing image](images/BarracudaLanding.png)

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -1,5 +1,5 @@
 <div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
-    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html>the Sentis package</a> instead.
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@latest/index.html">the Sentis package</a> instead.
 </div>
 
 ![Barracuda landing image](images/BarracudaLanding.png)

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -1,8 +1,12 @@
+<div style="background: #ffe2d7; padding: 16px; border-radius: 4px; margin: 16px 0;">
+    The Barracuda package is deprecated. Use <a href="https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html">the Sentis package</a> instead.
+</div>
+
 ![Barracuda landing image](images/BarracudaLanding.png)
 
 # Introduction to Barracuda
 
-**Note:** The Barracuda package has been replaced by the `Sentis` package, which is in a closed beta phase. Refer to the [Sentis documentation](https://docs.unity3d.com/Packages/com.unity.sentis@1.0) for more information.
+**Note:** The Barracuda package has been replaced by the `Sentis` package, which is in a closed beta phase. Refer to the [Sentis documentation](https://docs.unity3d.com/Packages/com.unity.sentis@2.1/manual/index.html) for more information.
 You can [sign up for the closed beta](https://create.unity.com/ai-beta).
 
 The Barracuda package is a lightweight cross-platform [neural network](https://en.wikipedia.org/wiki/Neural_network) inference library for Unity.  


### PR DESCRIPTION
Added a deprecation banner to barracuda documentation. Tested on local build. 
The banner reads:
```
The Barracuda package is deprecated. Use the Sentis package instead.
```
In the message, "Sentis package" links to the latest version of the Sentis documentation. 

It looks like this:
![image](https://github.com/user-attachments/assets/2088dda0-beea-417a-8fbc-4010d52165fc)

Once this content is approved and merged, I'll talk to docs engineering and get the Barracuda documentation with the new banner published. 